### PR TITLE
Fix creed lint reports

### DIFF
--- a/eolymp/ern/ern_test.go
+++ b/eolymp/ern/ern_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func TestERN_Includes(t *testing.T) {
+func TestName_Includes(t *testing.T) {
 	tt := []struct {
 		ERN      string
 		Parent   string
@@ -31,7 +31,7 @@ func TestERN_Includes(t *testing.T) {
 	}
 }
 
-func TestERN_MarshalJSON(t *testing.T) {
+func TestName_MarshalJSON(t *testing.T) {
 	tt := []struct {
 		ERN  string
 		JSON string
@@ -57,7 +57,7 @@ func TestERN_MarshalJSON(t *testing.T) {
 	}
 }
 
-func TestERN_UnmarshalJSON(t *testing.T) {
+func TestName_UnmarshalJSON(t *testing.T) {
 	tt := []struct {
 		ERN  string
 		JSON string
@@ -83,7 +83,7 @@ func TestERN_UnmarshalJSON(t *testing.T) {
 	}
 }
 
-func TestERN_MarshalBinary(t *testing.T) {
+func TestName_MarshalBinary(t *testing.T) {
 	tt := []struct {
 		ERN    string
 		Binary string
@@ -109,7 +109,7 @@ func TestERN_MarshalBinary(t *testing.T) {
 	}
 }
 
-func TestERN_UnmarshalBinary(t *testing.T) {
+func TestName_UnmarshalBinary(t *testing.T) {
 	tt := []struct {
 		ERN    string
 		Binary string


### PR DESCRIPTION
`creed lint` reported 5 findings on `main`, all `test_naming` in `eolymp/ern/ern_test.go`. The tests were named `TestERN_*`, but the package declares no `ERN` — the type is `Name`. All five methods they exercise (`Includes`, `MarshalJSON`, `UnmarshalJSON`, `MarshalBinary`, `UnmarshalBinary`) are methods on `Name`, so they are `TestName_*` now.

`eolymp/ern` is hand-written rather than generated from contracts, so this will survive the next SDK regeneration.

### Verification

`creed lint` exits 0, `gofmt`/`go build`/`go vet` clean, `eolymp/ern` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AthkZ4NRzEJ5Ggmb4kUafW